### PR TITLE
[고도화] 엔티티 코드 리팩토링 - equals(), hashcode()에서 필드 접근을 getter로 바꾸기

### DIFF
--- a/project-board/src/main/java/com/projectboard/domain/Article.java
+++ b/project-board/src/main/java/com/projectboard/domain/Article.java
@@ -54,12 +54,12 @@ public class Article extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Article article)) return false; // pattern matching 방식
-        return id != null && id.equals(article.id); // 영속화(id가 부여되지 않았다면) && id가 같지 않다면 동등성 x
+        if (!(o instanceof Article that)) return false; // pattern matching 방식
+        return this.getId() != null && this.getId().equals(that.getId()); // 영속화(id가 부여되지 않았다면) && id가 같지 않다면 동등성 x
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/project-board/src/main/java/com/projectboard/domain/ArticleComment.java
+++ b/project-board/src/main/java/com/projectboard/domain/ArticleComment.java
@@ -42,11 +42,11 @@ public class ArticleComment extends AuditingFields {
     public boolean equals(Object o) {
         if (this == o) return true;
         if(!(o instanceof ArticleComment that)) return false;
-        return id != null && id.equals(that.id);
+        return this.getId() != null && this.getId().equals(that.getId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id);
+        return Objects.hash(this.getId());
     }
 }

--- a/project-board/src/main/java/com/projectboard/domain/UserAccount.java
+++ b/project-board/src/main/java/com/projectboard/domain/UserAccount.java
@@ -44,12 +44,12 @@ public class UserAccount extends AuditingFields {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof UserAccount userAccount)) return false;
-        return userId != null && userId.equals(userAccount.getUserId());
+        if (!(o instanceof UserAccount that)) return false;
+        return this.getUserId() != null && this.getUserId().equals(that.getUserId());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(userId);
+        return Objects.hash(this.getUserId());
     }
 }


### PR DESCRIPTION
티티의 equals(), hashcode()가 값 비교를 하기 위해 필드 직접 접근하는 것을 getter 접근으로 바꾼다.
프록시 객체를 사용하는 하이버네이트의 지연 로딩을 고려하여, 값 비교를 제대로 수행하지 못하는 일이 없도록 한다.