### PR TITLE
[고도화] 추가 도메인 설계

### DIFF
--- a/project-board/src/main/java/com/projectboard/repostiory/querydsl/HashtagRepositoryCustomImpl.java
+++ b/project-board/src/main/java/com/projectboard/repostiory/querydsl/HashtagRepositoryCustomImpl.java
@@ -1,13 +1,15 @@
 package com.projectboard.repostiory.querydsl;
 
+import com.projectboard.domain.Hashtag;
 import com.projectboard.domain.QHashtag;
 import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
 
 import java.util.List;
 
-public class HashtagRepositoryCustomImpl extends QuerydslRepositorySupport implements HashtagRepositoryCustom{
-    public HashtagRepositoryCustomImpl(Class<?> domainClass) {
-        super(domainClass);
+public class HashtagRepositoryCustomImpl extends QuerydslRepositorySupport implements HashtagRepositoryCustom {
+
+    public HashtagRepositoryCustomImpl() {
+        super(Hashtag.class);
     }
 
     @Override
@@ -18,4 +20,5 @@ public class HashtagRepositoryCustomImpl extends QuerydslRepositorySupport imple
                 .select(hashtag.hashtagName)
                 .fetch();
     }
+
 }


### PR DESCRIPTION
QueryDSL 서비스 생성자 오류 수정
HashTag 클래스를 넘겨줘야 함.

fixed #34 