### PR TITLE
[고도화] 해시태그 검색 기능 고도화

### DIFF
--- a/project-board/src/main/java/com/projectboard/controller/ArticleController.java
+++ b/project-board/src/main/java/com/projectboard/controller/ArticleController.java
@@ -42,6 +42,7 @@ public class ArticleController {
         map.addAttribute("articles", articles);
         map.addAttribute("paginationBarNumbers", barNumbers);
         map.addAttribute("searchTypes", SearchType.values());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/index";
     }
@@ -53,6 +54,7 @@ public class ArticleController {
         map.addAttribute("article", article);
         map.addAttribute("articleComments", article.articleCommentsResponse());
         map.addAttribute("totalCount", articleService.getArticleCount());
+        map.addAttribute("searchTypeHashtag", SearchType.HASHTAG);
 
         return "articles/detail";
     }

--- a/project-board/src/main/java/com/projectboard/service/HashtagService.java
+++ b/project-board/src/main/java/com/projectboard/service/HashtagService.java
@@ -1,19 +1,46 @@
 package com.projectboard.service;
 
+import com.projectboard.domain.Hashtag;
+import com.projectboard.repostiory.HashtagRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
+@Transactional
+@RequiredArgsConstructor
 @Service
 public class HashtagService {
-    public Object parseHashtagNames(String content) {
-        return null;
+    private final HashtagRepository hashtagRepository;
+
+    public Set<String> parseHashtagNames(String content) {
+        if (content == null) {
+            return Set.of();
+        }
+
+        Pattern pattern = Pattern.compile("#[\\w가-힣]+");
+        Matcher matcher = pattern.matcher(content.strip());
+        Set<String> result = new HashSet<>();
+
+        while (matcher.find()) {
+            result.add(matcher.group().replace("#", ""));
+        }
+
+        return Set.copyOf(result);
     }
 
-    public Object findHashtagsByNames(Set<String> expectedHashtagNames) {
-        return null;
+    public Set<Hashtag> findHashtagsByNames(Set<String> hashtagNames) {
+        return new HashSet<>(hashtagRepository.findByHashtagNameIn(hashtagNames));
     }
 
-    public void deleteHashtagWithoutArticles(Object any) {
+    public void deleteHashtagWithoutArticles(Long hashtagId) {
+        Hashtag hashtag = hashtagRepository.getReferenceById(hashtagId);
+        if (hashtag.getArticles().isEmpty()) {
+            hashtagRepository.delete(hashtag);
+        }
     }
 }

--- a/project-board/src/main/resources/templates/articles/detail.html
+++ b/project-board/src/main/resources/templates/articles/detail.html
@@ -32,7 +32,7 @@
                 <p>
                     <time id="created-at" datetime="2022-01-01T00:00:00">2022-01-01</time>
                 </p>
-                <p><span id="hashtag">#java</span></p>
+                <p><span id="hashtag" class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></p>
             </aside>
         </section>
 

--- a/project-board/src/main/resources/templates/articles/detail.th.xml
+++ b/project-board/src/main/resources/templates/articles/detail.th.xml
@@ -9,10 +9,16 @@
         <attr sel="#email" th:text="*{email}"/>
         <attr sel="#created-at" th:datetime="*{createdAt}"
               th:text="*{#temporals.format(createdAt, 'yyyy-MM-dd HH:mm:ss')}"/>
-        <attr sel="#hashtag" th:text="*{hashtag}"/>
+        <attr sel="#hashtag" th:each="hashtag : ${article.hashtags}">
+            <attr sel="a"
+                  th:text="'#' + ${hashtag}"
+                  th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
+            />
+        </attr>
         <attr sel="#article-content/pre" th:text="*{content}"/>
 
-        <attr sel="#article-buttons" th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">
+        <attr sel="#article-buttons"
+              th:if="${#authorization.expression('isAuthenticated()')} and *{userId} == ${#authentication.name}">
             <attr sel="#delete-article-form" th:action="'/articles/' + *{id} + '/delete'" th:method="post">
                 <attr sel="#update-article" th:href="'/articles/' + *{id} + '/form'"/>
             </attr>
@@ -30,7 +36,8 @@
                     <attr sel="div/small/time" th:datetime="${articleComment.createdAt}"
                           th:text="${#temporals.format(articleComment.createdAt, 'yyyy-MM-dd HH:mm:ss')}"/>
                     <attr sel="div/p" th:text="${articleComment.content}"/>
-                    <attr sel="button" th:if="${#authorization.expression('isAuthenticated()')} and ${articleComment.userId} == ${#authentication.name}" />
+                    <attr sel="button"
+                          th:if="${#authorization.expression('isAuthenticated()')} and ${articleComment.userId} == ${#authentication.name}"/>
                 </attr>
             </attr>
         </attr>

--- a/project-board/src/main/resources/templates/articles/form.html
+++ b/project-board/src/main/resources/templates/articles/form.html
@@ -35,12 +35,6 @@
                 <textarea class="form-control" id="content" name="content" rows="5" required></textarea>
             </div>
         </div>
-        <div class="row mb-4 justify-content-md-center">
-            <label for="hashtag" class="col-sm-2 col-lg-1 col-form-label text-sm-end">해시태그</label>
-            <div class="col-sm-8 col-lg-9">
-                <input type="text" class="form-control" id="hashtag" name="hashtag">
-            </div>
-        </div>
         <div class="row mb-5 justify-content-md-center">
             <div class="col-sm-10 d-grid gap-2 d-sm-flex justify-content-sm-end">
                 <button type="submit" class="btn btn-primary" id="submit-button">저장</button>

--- a/project-board/src/main/resources/templates/articles/form.th.xml
+++ b/project-board/src/main/resources/templates/articles/form.th.xml
@@ -8,7 +8,6 @@
     <attr sel="#article-form" th:action="${formStatus?.update} ? '/articles/' + ${article.id} + '/form' : '/articles/form'" th:method="post">
         <attr sel="#title" th:value="${article?.title} ?: _" />
         <attr sel="#content" th:text="${article?.content} ?: _" />
-        <attr sel="#hashtag" th:value="${article?.hashtag} ?: _" />
         <attr sel="#submit-button" th:text="${formStatus?.description} ?: _" />
         <attr sel="#cancel-button" th:onclick="'history.back()'" />
     </attr>

--- a/project-board/src/main/resources/templates/articles/index.html
+++ b/project-board/src/main/resources/templates/articles/index.html
@@ -77,7 +77,7 @@
             <tbody>
             <tr>
                 <td class="title"><a>첫글1</a></td>
-                <td class="hashtag">#java</td>
+                <td class="hashtag"><span class="badge text-bg-secondary mx-1"><a class="text-reset">#java</a></span></td>
                 <td class="user-id">kkm</td>
                 <td class="created-at">
                     <time>2022-01-02</time>

--- a/project-board/src/main/resources/templates/articles/index.th.xml
+++ b/project-board/src/main/resources/templates/articles/index.th.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <thlogic>
-    <attr sel="#header" th:replace="header :: header"/>
-    <attr sel="#footer" th:replace="footer :: footer"/>
+    <attr sel="#header" th:replace="header :: header" />
+    <attr sel="#footer" th:replace="footer :: footer" />
 
     <attr sel="main" th:object="${articles}">
         <attr sel="#search-form" th:action="@{/articles}" th:method="get" />
@@ -25,7 +25,7 @@
         )}"/>
                 <attr sel="th.hashtag/a" th:text="'해시태그'" th:href="@{/articles(
             page=${articles.number},
-            sort='hashtag' + (*{sort.getOrderFor('hashtag')} != null ? (*{sort.getOrderFor('hashtag').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            sort='hashtags' + (*{sort.getOrderFor('hashtags')} != null ? (*{sort.getOrderFor('hashtags').direction.name} != 'DESC' ? ',desc' : '') : ''),
             searchType=${param.searchType},
             searchValue=${param.searchValue}
         )}"/>
@@ -45,11 +45,15 @@
 
             <attr sel="tbody" th:remove="all-but-first">
                 <attr sel="tr[0]" th:each="article : ${articles}">
-                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}"/>
-                    <attr sel="td.hashtag" th:text="${article.hashtag}"/>
-                    <attr sel="td.user-id" th:text="${article.nickname}"/>
-                    <attr sel="td.created-at/time" th:datetime="${article.createdAt}"
-                          th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}"/>
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
+                    <attr sel="td.hashtag/span" th:each="hashtag : ${article.hashtags}">
+                        <attr sel="a"
+                              th:text="'#' + ${hashtag}"
+                              th:href="@{/articles(searchType=${searchTypeHashtag},searchValue=${hashtag})}"
+                        />
+                    </attr>
+                    <attr sel="td.user-id" th:text="${article.nickname}" />
+                    <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
                 </attr>
             </attr>
         </attr>
@@ -59,7 +63,7 @@
         <attr sel="#pagination">
             <attr sel="li[0]/a"
                   th:text="'previous'"
-                  th:href="@{/articles(page=${articles.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue})} "
+                  th:href="@{/articles(page=${articles.number - 1}, searchType=${param.searchType}, searchValue=${param.searchValue})}"
                   th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
             />
             <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
@@ -77,4 +81,3 @@
         </attr>
     </attr>
 </thlogic>
-

--- a/project-board/src/test/java/com/projectboard/service/HashtagServiceTest.java
+++ b/project-board/src/test/java/com/projectboard/service/HashtagServiceTest.java
@@ -1,0 +1,113 @@
+package com.projectboard.service;
+
+
+import com.projectboard.domain.Hashtag;
+import com.projectboard.repostiory.HashtagRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+
+@DisplayName("비즈니스 로직 - 해시태그")
+@ExtendWith(MockitoExtension.class)
+class HashtagServiceTest {
+
+    @InjectMocks
+    private HashtagService sut;
+
+    @Mock
+    private HashtagRepository hashtagRepository;
+
+    @DisplayName("본문을 파싱하면, 해시태그 이름들을 중복 없이 반환한다.")
+    @MethodSource
+    @ParameterizedTest(name = "[{index}] \"{0}\" => {1}")
+    void givenContent_whenParsing_thenReturnsUniqueHashtagNames(String input, Set<String> expected) {
+        // Given
+
+        // When
+        Set<String> actual = sut.parseHashtagNames(input);
+
+        // Then
+        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+        then(hashtagRepository).shouldHaveNoInteractions();
+
+    }
+
+    static Stream<Arguments> givenContent_whenParsing_thenReturnsUniqueHashtagNames() {
+        return Stream.of(
+                arguments(null, Set.of()),
+                arguments("", Set.of()),
+                arguments("   ", Set.of()),
+                arguments("#", Set.of()),
+                arguments("  #", Set.of()),
+                arguments("#   ", Set.of()),
+                arguments("java", Set.of()),
+                arguments("java#", Set.of()),
+                arguments("ja#va", Set.of("va")),
+                arguments("#java", Set.of("java")),
+                arguments("#java_spring", Set.of("java_spring")),
+                arguments("#java-spring", Set.of("java")),
+                arguments("#_java_spring", Set.of("_java_spring")),
+                arguments("#-java-spring", Set.of()),
+                arguments("#_java_spring__", Set.of("_java_spring__")),
+                arguments("#java#spring", Set.of("java", "spring")),
+                arguments("#java #spring", Set.of("java", "spring")),
+                arguments("#java  #spring", Set.of("java", "spring")),
+                arguments("#java   #spring", Set.of("java", "spring")),
+                arguments("#java     #spring", Set.of("java", "spring")),
+                arguments("  #java     #spring ", Set.of("java", "spring")),
+                arguments("   #java     #spring   ", Set.of("java", "spring")),
+                arguments("#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring #부트", Set.of("java", "spring", "부트")),
+                arguments("#java,#spring,#부트", Set.of("java", "spring", "부트")),
+                arguments("#java.#spring;#부트", Set.of("java", "spring", "부트")),
+                arguments("#java|#spring:#부트", Set.of("java", "spring", "부트")),
+                arguments("#java #spring  #부트", Set.of("java", "spring", "부트")),
+                arguments("   #java,? #spring  ...  #부트 ", Set.of("java", "spring", "부트")),
+                arguments("#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#java#java#spring#부트", Set.of("java", "spring", "부트")),
+                arguments("#java#spring#java#부트#java", Set.of("java", "spring", "부트")),
+                arguments("#java#스프링 아주 긴 글~~~~~~~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~~~~~~~~~~~~~~~~#java#스프링", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java#스프링~~~~~~~~~~~~~~~", Set.of("java", "스프링")),
+                arguments("아주 긴 글~~~~~~#java~~~~~~~#스프링~~~~~~~~", Set.of("java", "스프링"))
+        );
+    }
+
+    @DisplayName("해시태그 이름들을 입력하면, 저장된 해시태그 중 이름에 매칭하는 것들을 중복 없이 반환한다.")
+    @Test
+    void givenHashtagNames_whenFindingHashtags_thenReturnsHashtagSet() {
+        // Given
+        Set<String> hashtagNames = Set.of("java", "spring", "boots");
+        given(hashtagRepository.findByHashtagNameIn(hashtagNames)).willReturn(List.of(
+                Hashtag.of("java"),
+                Hashtag.of("spring")
+        ));
+
+        // When
+        Set<Hashtag> hashtags = sut.findHashtagsByNames(hashtagNames);
+
+        // Then
+        assertThat(hashtags).hasSize(2);
+        then(hashtagRepository).should().findByHashtagNameIn(hashtagNames);
+    }
+
+
+
+}


### PR DESCRIPTION
해시태그 기능을 고도화한다.

-  하나의 글이 여러 개의 해시태그를 저장할 수 있도록 만들기
-  별도 입력 공간을 주지 않고, 본문에서 해시태그를 파싱해서 기록하기
-  DB에는 #을 뺀 문자열을 저장할 수 있게 하기
-  해시태그에 링크를 삽입하기

This closes #37 